### PR TITLE
Adding Custom Rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,30 @@ ratelimit = Ratelimit(
 )
 ```
 
+# Custom Rates
+
+When rate limiting, you may want different requests to consume different amounts of tokens.
+This could be useful when processing batches of requests where you want to rate limit based
+on items in the batch or when you want to rate limit based on the number of tokens.
+
+To achieve this, you can simply pass `rate` parameter when calling the limit method:
+
+```python
+
+from upstash_ratelimit import Ratelimit, FixedWindow
+from upstash_redis import Redis
+
+ratelimit = Ratelimit(
+    redis=Redis.from_env(),
+    limiter=FixedWindow(max_requests=10, window=10),
+)
+
+# pass rate as 5 to subtract 5 from the number of
+# allowed requests in the window:
+identifier = "api"
+response = ratelimit.limit(identifier, rate=5)
+```
+
 # Contributing
 
 ## Preparing the environment

--- a/tests/test_fixed_window.py
+++ b/tests/test_fixed_window.py
@@ -84,3 +84,20 @@ def test_get_reset(redis: Redis) -> None:
 
     with patch("time.time", return_value=1688910786.167):
         assert ratelimit.get_reset(random_id()) == approx(1688910790.0)
+
+
+def test_custom_rate(redis: Redis) -> None:
+    ratelimit = Ratelimit(
+        redis=redis,
+        limiter=FixedWindow(max_requests=10, window=1, unit="d"),
+    )
+    rate = 2
+
+    id = random_id()
+
+    ratelimit.limit(id)
+    ratelimit.limit(id, rate)
+    assert ratelimit.get_remaining(id) == 7
+
+    ratelimit.limit(id, rate)
+    assert ratelimit.get_remaining(id) == 5

--- a/tests/test_sliding_window.py
+++ b/tests/test_sliding_window.py
@@ -130,3 +130,20 @@ def test_get_reset(redis: Redis) -> None:
 
     with patch("time.time", return_value=1688910786.167):
         assert ratelimit.get_reset(random_id()) == approx(1688910790.0)
+
+
+def test_custom_rate(redis: Redis) -> None:
+    ratelimit = Ratelimit(
+        redis=redis,
+        limiter=SlidingWindow(max_requests=10, window=5),
+    )
+    rate = 2
+
+    id = random_id()
+
+    ratelimit.limit(id)
+    ratelimit.limit(id, rate)
+    assert ratelimit.get_remaining(id) == 7
+
+    ratelimit.limit(id, rate)
+    assert ratelimit.get_remaining(id) == 5

--- a/tests/test_token_bucket.py
+++ b/tests/test_token_bucket.py
@@ -146,3 +146,20 @@ def test_get_reset_with_refills_that_should_be_made(redis: Redis) -> None:
     time.sleep(3)
 
     assert ratelimit.get_reset(id) >= last_reset + 2
+
+
+def test_custom_rate(redis: Redis) -> None:
+    ratelimit = Ratelimit(
+        redis=redis,
+        limiter=TokenBucket(max_tokens=10, refill_rate=1, interval=1),
+    )
+    rate = 2
+
+    id = random_id()
+
+    ratelimit.limit(id)
+    ratelimit.limit(id, rate)
+    assert ratelimit.get_remaining(id) == 7
+
+    ratelimit.limit(id, rate)
+    assert ratelimit.get_remaining(id) == 5

--- a/upstash_ratelimit/ratelimit.py
+++ b/upstash_ratelimit/ratelimit.py
@@ -32,7 +32,7 @@ class Ratelimit:
         self._limiter = limiter
         self._prefix = prefix
 
-    def limit(self, identifier: str) -> Response:
+    def limit(self, identifier: str, rate: int = 1) -> Response:
         """
         Determines if a request should pass or be rejected based on the identifier 
         and previously chosen ratelimit.
@@ -59,12 +59,14 @@ class Ratelimit:
         :param identifier: Identifier to ratelimit. Use a constant string to \
             limit all requests, or user ids, API keys, or IP addresses for \
             individual limits.
+        :param rate: Rate with which to subtract from the limit of the \
+            identifier.
         """
 
         key = f"{self._prefix}:{identifier}"
-        return self._limiter.limit(self._redis, key)
+        return self._limiter.limit(self._redis, key, rate)
 
-    def block_until_ready(self, identifier: str, timeout: float) -> Response:
+    def block_until_ready(self, identifier: str, timeout: float, rate: int = 1) -> Response:
         """
         Blocks until the request may pass or timeout is reached.
         
@@ -95,6 +97,8 @@ class Ratelimit:
             individual limits.
         :param timeout: Maximum time in seconds to wait until the request \
             may pass.
+        :param rate: Rate with which to subtract from the limit of the \
+            identifier.
         """
 
         if timeout <= 0:
@@ -104,7 +108,7 @@ class Ratelimit:
         deadline = now_s() + timeout
 
         while True:
-            response = self.limit(identifier)
+            response = self.limit(identifier, rate)
             if response.allowed:
                 break
 


### PR DESCRIPTION
With this change, it is now possible to rate limit with a custom rate:

```python

from upstash_ratelimit import Ratelimit, FixedWindow
from upstash_redis import Redis

ratelimit = Ratelimit(
    redis=Redis.from_env(),
    limiter=FixedWindow(max_requests=10, window=10),
)

# pass rate as 5 to subtract 5 from the number of
# allowed requests in the window:
identifier = "api"
response = ratelimit.limit(identifier, rate=5)
```